### PR TITLE
Upgrade spring framework to 5.3.36-wso2v1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,10 +69,14 @@ dependencies {
 
     dependencyManagement {
         dependencies {
-            dependency group: 'org.springframework', name: 'spring-beans', version: springFrameworkVersion
-            dependency group: 'org.springframework', name: 'spring-expression', version: springFrameworkVersion
             dependency group: 'org.springframework', name: 'spring-aop', version: springFrameworkVersion
+            dependency group: 'org.springframework', name: 'spring-beans', version: springFrameworkVersion
             dependency group: 'org.springframework', name: 'spring-context', version: springFrameworkVersion
+            dependency group: 'org.springframework', name: 'spring-core', version: springFrameworkVersion
+            dependency group: 'org.springframework', name: 'spring-expression', version: springFrameworkVersion
+            dependency group: 'org.springframework', name: 'spring-jcl', version: springFrameworkVersion
+            dependency group: 'org.springframework', name: 'spring-web', version: springFrameworkVersion
+            dependency group: 'org.springframework', name: 'spring-webmvc', version: springFrameworkVersion
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,7 @@ dependencies {
             dependency group: 'org.springframework', name: 'spring-beans', version: springFrameworkVersion
             dependency group: 'org.springframework', name: 'spring-expression', version: springFrameworkVersion
             dependency group: 'org.springframework', name: 'spring-aop', version: springFrameworkVersion
+            dependency group: 'org.springframework', name: 'spring-context', version: springFrameworkVersion
         }
     }
 


### PR DESCRIPTION
**Summary**
- The BD scans kept reporting CVEs for different spring framework 5.3.31 libraries. 
- Upgrading all of them to the suggested (5.3.36-wso2v1) version.